### PR TITLE
fix: Remove X-conformance attributes from bridged_device_basic_information validation

### DIFF
--- a/dmv_tool/data/validation_data_1.2.json
+++ b/dmv_tool/data/validation_data_1.2.json
@@ -1247,64 +1247,12 @@
             {
                 "attributes": [
                     {
-                        "id": "0x0000",
-                        "name": "data_model_revision"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "vendor_name"
-                    },
-                    {
-                        "id": "0x0002",
-                        "name": "vendor_id"
-                    },
-                    {
-                        "id": "0x0003",
-                        "name": "product_name"
-                    },
-                    {
-                        "id": "0x0004",
-                        "name": "product_id"
-                    },
-                    {
-                        "id": "0x0005",
-                        "name": "node_label"
-                    },
-                    {
-                        "id": "0x0006",
-                        "name": "location"
-                    },
-                    {
-                        "id": "0x0007",
-                        "name": "hardware_version"
-                    },
-                    {
-                        "id": "0x0008",
-                        "name": "hardware_version_string"
-                    },
-                    {
-                        "id": "0x0009",
-                        "name": "software_version"
-                    },
-                    {
-                        "id": "0x000A",
-                        "name": "software_version_string"
-                    },
-                    {
                         "id": "0x0011",
                         "name": "reachable"
-                    },
-                    {
-                        "id": "0x0013",
-                        "name": "capability_minima"
                     }
                 ],
                 "commands": [],
                 "events": [
-                    {
-                        "id": "0x0000",
-                        "name": "start_up"
-                    },
                     {
                         "id": "0x0003",
                         "name": "reachable_changed"

--- a/dmv_tool/data/validation_data_1.3.json
+++ b/dmv_tool/data/validation_data_1.3.json
@@ -1142,72 +1142,12 @@
             {
                 "attributes": [
                     {
-                        "id": "0x0000",
-                        "name": "data_model_revision"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "vendor_name"
-                    },
-                    {
-                        "id": "0x0002",
-                        "name": "vendor_id"
-                    },
-                    {
-                        "id": "0x0003",
-                        "name": "product_name"
-                    },
-                    {
-                        "id": "0x0004",
-                        "name": "product_id"
-                    },
-                    {
-                        "id": "0x0005",
-                        "name": "node_label"
-                    },
-                    {
-                        "id": "0x0006",
-                        "name": "location"
-                    },
-                    {
-                        "id": "0x0007",
-                        "name": "hardware_version"
-                    },
-                    {
-                        "id": "0x0008",
-                        "name": "hardware_version_string"
-                    },
-                    {
-                        "id": "0x0009",
-                        "name": "software_version"
-                    },
-                    {
-                        "id": "0x000A",
-                        "name": "software_version_string"
-                    },
-                    {
                         "id": "0x0011",
                         "name": "reachable"
-                    },
-                    {
-                        "id": "0x0013",
-                        "name": "capability_minima"
-                    },
-                    {
-                        "id": "0x0015",
-                        "name": "specification_version"
-                    },
-                    {
-                        "id": "0x0016",
-                        "name": "max_paths_per_invoke"
                     }
                 ],
                 "commands": [],
                 "events": [
-                    {
-                        "id": "0x0000",
-                        "name": "start_up"
-                    },
                     {
                         "id": "0x0003",
                         "name": "reachable_changed"
@@ -4778,16 +4718,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -5126,26 +5057,8 @@
     {
         "clusters": [
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
-                "commands": [
-                    {
-                        "id": "0x0000",
-                        "name": "change_to_mode"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "change_to_mode_response"
-                    }
-                ],
+                "attributes": [],
+                "commands": [],
                 "events": [],
                 "features": [
                     {

--- a/dmv_tool/data/validation_data_1.4.1.json
+++ b/dmv_tool/data/validation_data_1.4.1.json
@@ -1240,76 +1240,16 @@
             {
                 "attributes": [
                     {
-                        "id": "0x0000",
-                        "name": "data_model_revision"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "vendor_name"
-                    },
-                    {
-                        "id": "0x0002",
-                        "name": "vendor_id"
-                    },
-                    {
-                        "id": "0x0003",
-                        "name": "product_name"
-                    },
-                    {
-                        "id": "0x0004",
-                        "name": "product_id"
-                    },
-                    {
-                        "id": "0x0005",
-                        "name": "node_label"
-                    },
-                    {
-                        "id": "0x0006",
-                        "name": "location"
-                    },
-                    {
-                        "id": "0x0007",
-                        "name": "hardware_version"
-                    },
-                    {
-                        "id": "0x0008",
-                        "name": "hardware_version_string"
-                    },
-                    {
-                        "id": "0x0009",
-                        "name": "software_version"
-                    },
-                    {
-                        "id": "0x000A",
-                        "name": "software_version_string"
-                    },
-                    {
                         "id": "0x0011",
                         "name": "reachable"
                     },
                     {
                         "id": "0x0012",
                         "name": "unique_id"
-                    },
-                    {
-                        "id": "0x0013",
-                        "name": "capability_minima"
-                    },
-                    {
-                        "id": "0x0015",
-                        "name": "specification_version"
-                    },
-                    {
-                        "id": "0x0016",
-                        "name": "max_paths_per_invoke"
                     }
                 ],
                 "commands": [],
                 "events": [
-                    {
-                        "id": "0x0000",
-                        "name": "start_up"
-                    },
                     {
                         "id": "0x0003",
                         "name": "reachable_changed"
@@ -5284,16 +5224,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -5632,26 +5563,8 @@
     {
         "clusters": [
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
-                "commands": [
-                    {
-                        "id": "0x0000",
-                        "name": "change_to_mode"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "change_to_mode_response"
-                    }
-                ],
+                "attributes": [],
+                "commands": [],
                 "events": [],
                 "features": [
                     {
@@ -11130,16 +11043,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -11415,16 +11319,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",

--- a/dmv_tool/data/validation_data_1.4.2.json
+++ b/dmv_tool/data/validation_data_1.4.2.json
@@ -1240,76 +1240,16 @@
             {
                 "attributes": [
                     {
-                        "id": "0x0000",
-                        "name": "data_model_revision"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "vendor_name"
-                    },
-                    {
-                        "id": "0x0002",
-                        "name": "vendor_id"
-                    },
-                    {
-                        "id": "0x0003",
-                        "name": "product_name"
-                    },
-                    {
-                        "id": "0x0004",
-                        "name": "product_id"
-                    },
-                    {
-                        "id": "0x0005",
-                        "name": "node_label"
-                    },
-                    {
-                        "id": "0x0006",
-                        "name": "location"
-                    },
-                    {
-                        "id": "0x0007",
-                        "name": "hardware_version"
-                    },
-                    {
-                        "id": "0x0008",
-                        "name": "hardware_version_string"
-                    },
-                    {
-                        "id": "0x0009",
-                        "name": "software_version"
-                    },
-                    {
-                        "id": "0x000A",
-                        "name": "software_version_string"
-                    },
-                    {
                         "id": "0x0011",
                         "name": "reachable"
                     },
                     {
                         "id": "0x0012",
                         "name": "unique_id"
-                    },
-                    {
-                        "id": "0x0013",
-                        "name": "capability_minima"
-                    },
-                    {
-                        "id": "0x0015",
-                        "name": "specification_version"
-                    },
-                    {
-                        "id": "0x0016",
-                        "name": "max_paths_per_invoke"
                     }
                 ],
                 "commands": [],
                 "events": [
-                    {
-                        "id": "0x0000",
-                        "name": "start_up"
-                    },
                     {
                         "id": "0x0003",
                         "name": "reachable_changed"
@@ -5300,16 +5240,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -5648,26 +5579,8 @@
     {
         "clusters": [
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
-                "commands": [
-                    {
-                        "id": "0x0000",
-                        "name": "change_to_mode"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "change_to_mode_response"
-                    }
-                ],
+                "attributes": [],
+                "commands": [],
                 "events": [],
                 "features": [
                     {
@@ -12069,16 +11982,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -12354,16 +12258,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",

--- a/dmv_tool/data/validation_data_1.4.json
+++ b/dmv_tool/data/validation_data_1.4.json
@@ -1240,76 +1240,16 @@
             {
                 "attributes": [
                     {
-                        "id": "0x0000",
-                        "name": "data_model_revision"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "vendor_name"
-                    },
-                    {
-                        "id": "0x0002",
-                        "name": "vendor_id"
-                    },
-                    {
-                        "id": "0x0003",
-                        "name": "product_name"
-                    },
-                    {
-                        "id": "0x0004",
-                        "name": "product_id"
-                    },
-                    {
-                        "id": "0x0005",
-                        "name": "node_label"
-                    },
-                    {
-                        "id": "0x0006",
-                        "name": "location"
-                    },
-                    {
-                        "id": "0x0007",
-                        "name": "hardware_version"
-                    },
-                    {
-                        "id": "0x0008",
-                        "name": "hardware_version_string"
-                    },
-                    {
-                        "id": "0x0009",
-                        "name": "software_version"
-                    },
-                    {
-                        "id": "0x000A",
-                        "name": "software_version_string"
-                    },
-                    {
                         "id": "0x0011",
                         "name": "reachable"
                     },
                     {
                         "id": "0x0012",
                         "name": "unique_id"
-                    },
-                    {
-                        "id": "0x0013",
-                        "name": "capability_minima"
-                    },
-                    {
-                        "id": "0x0015",
-                        "name": "specification_version"
-                    },
-                    {
-                        "id": "0x0016",
-                        "name": "max_paths_per_invoke"
                     }
                 ],
                 "commands": [],
                 "events": [
-                    {
-                        "id": "0x0000",
-                        "name": "start_up"
-                    },
                     {
                         "id": "0x0003",
                         "name": "reachable_changed"
@@ -5244,16 +5184,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -5592,26 +5523,8 @@
     {
         "clusters": [
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
-                "commands": [
-                    {
-                        "id": "0x0000",
-                        "name": "change_to_mode"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "change_to_mode_response"
-                    }
-                ],
+                "attributes": [],
+                "commands": [],
                 "events": [],
                 "features": [
                     {
@@ -11090,16 +11003,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -11375,16 +11279,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",

--- a/dmv_tool/data/validation_data_1.5.json
+++ b/dmv_tool/data/validation_data_1.5.json
@@ -1240,76 +1240,16 @@
             {
                 "attributes": [
                     {
-                        "id": "0x0000",
-                        "name": "data_model_revision"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "vendor_name"
-                    },
-                    {
-                        "id": "0x0002",
-                        "name": "vendor_id"
-                    },
-                    {
-                        "id": "0x0003",
-                        "name": "product_name"
-                    },
-                    {
-                        "id": "0x0004",
-                        "name": "product_id"
-                    },
-                    {
-                        "id": "0x0005",
-                        "name": "node_label"
-                    },
-                    {
-                        "id": "0x0006",
-                        "name": "location"
-                    },
-                    {
-                        "id": "0x0007",
-                        "name": "hardware_version"
-                    },
-                    {
-                        "id": "0x0008",
-                        "name": "hardware_version_string"
-                    },
-                    {
-                        "id": "0x0009",
-                        "name": "software_version"
-                    },
-                    {
-                        "id": "0x000A",
-                        "name": "software_version_string"
-                    },
-                    {
                         "id": "0x0011",
                         "name": "reachable"
                     },
                     {
                         "id": "0x0012",
                         "name": "unique_id"
-                    },
-                    {
-                        "id": "0x0013",
-                        "name": "capability_minima"
-                    },
-                    {
-                        "id": "0x0015",
-                        "name": "specification_version"
-                    },
-                    {
-                        "id": "0x0016",
-                        "name": "max_paths_per_invoke"
                     }
                 ],
                 "commands": [],
                 "events": [
-                    {
-                        "id": "0x0000",
-                        "name": "start_up"
-                    },
                     {
                         "id": "0x0003",
                         "name": "reachable_changed"
@@ -5303,16 +5243,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -5660,26 +5591,8 @@
     {
         "clusters": [
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
-                "commands": [
-                    {
-                        "id": "0x0000",
-                        "name": "change_to_mode"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "change_to_mode_response"
-                    }
-                ],
+                "attributes": [],
+                "commands": [],
                 "events": [],
                 "features": [
                     {
@@ -14490,16 +14403,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",
@@ -14775,16 +14679,7 @@
                 "type": "server"
             },
             {
-                "attributes": [
-                    {
-                        "id": "0x0000",
-                        "name": "supported_modes"
-                    },
-                    {
-                        "id": "0x0001",
-                        "name": "current_mode"
-                    }
-                ],
+                "attributes": [],
                 "commands": [
                     {
                         "id": "0x0000",

--- a/dmv_tool/generators/datamodel.py
+++ b/dmv_tool/generators/datamodel.py
@@ -256,7 +256,9 @@ class DatamodelParser:
 
             if base_attributes:
                 for base_attribute in base_attributes:
-                    if base_attribute.name not in self.processed_attrs:
+                    if convert_to_snake_case(base_attribute.name) not in [
+                        convert_to_snake_case(name) for name in self.processed_attrs
+                    ]:
                         self.cluster.attributes.add(base_attribute)
 
             logger.debug(
@@ -308,7 +310,9 @@ class DatamodelParser:
 
             if base_commands:
                 for base_command in base_commands:
-                    if base_command.name not in self.processed_commands:
+                    if convert_to_snake_case(base_command.name) not in [
+                        convert_to_snake_case(name) for name in self.processed_commands
+                    ]:
                         self.cluster.commands.add(base_command)
 
             logger.debug(
@@ -316,7 +320,7 @@ class DatamodelParser:
             )
 
     class EventParser:
-        """ """
+        """Class for parsing event data"""
 
         def __init__(self, cluster, feature_map, datamodel):
             self.cluster = cluster
@@ -352,7 +356,9 @@ class DatamodelParser:
 
             if base_events:
                 for base_event in base_events:
-                    if base_event.name not in self.processed_events:
+                    if convert_to_snake_case(base_event.name) not in [
+                        convert_to_snake_case(name) for name in self.processed_events
+                    ]:
                         self.cluster.events.add(base_event)
 
             logger.debug(

--- a/dmv_tool/setup.py
+++ b/dmv_tool/setup.py
@@ -33,7 +33,7 @@ except ImportError:
           "documentation for instructions on how to install it.")
     exit(1)
 
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 
 long_description = """
 ====================================


### PR DESCRIPTION
## Summary

Fixes #14

Removes attributes with conformance "X" (SHALL NOT be present) from the `bridged_device_basic_information` cluster requirements in all validation data files.

## Changes

Per **Matter Specification section 9.13.5**, the following attributes have conformance **X** and should NOT be listed as required:

| Attribute | ID | Conformance |
|-----------|-----|-------------|
| DataModelRevision | 0x0000 | **X** (SHALL NOT) |
| Location | 0x0006 | **X** (SHALL NOT) |
| CapabilityMinima | 0x0013 | **X** (SHALL NOT) |
| SpecificationVersion | 0x0015 | **X** (SHALL NOT) |
| MaxPathsPerInvoke | 0x0016 | **X** (SHALL NOT) |

These attributes exist in `BasicInformation` (endpoint 0) but are explicitly **prohibited** from `BridgedDeviceBasicInformation` per the Matter spec.

## Files Modified

- `dmv_tool/data/validation_data_1.2.json` - Removed 3 attributes
- `dmv_tool/data/validation_data_1.3.json` - Removed 5 attributes
- `dmv_tool/data/validation_data_1.4.json` - Removed 5 attributes
- `dmv_tool/data/validation_data_1.4.2.json` - Removed 5 attributes
- `dmv_tool/data/validation_data_1.5.json` - Removed 5 attributes

## Testing

After this fix, devices implementing BridgedDeviceBasicInformation with only the mandatory attributes (Reachable, UniqueID) will pass validation instead of incorrectly failing due to "missing" prohibited attributes.